### PR TITLE
feat: allow `EguiEditor.user_state` without `Sync`

### DIFF
--- a/nih_plug_egui/src/lib.rs
+++ b/nih_plug_egui/src/lib.rs
@@ -9,8 +9,8 @@ use crossbeam::atomic::AtomicCell;
 use egui::Context;
 use nih_plug::params::persist::PersistentField;
 use nih_plug::prelude::{Editor, ParamSetter};
-use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
+use std::cell::Cell;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
@@ -40,13 +40,13 @@ pub fn create_egui_editor<T, B, U>(
     update: U,
 ) -> Option<Box<dyn Editor>>
 where
-    T: 'static + Send + Sync,
+    T: 'static + Send,
     B: Fn(&Context, &mut T) + 'static + Send + Sync,
     U: Fn(&Context, &ParamSetter, &mut T) + 'static + Send + Sync,
 {
     Some(Box::new(editor::EguiEditor {
         egui_state,
-        user_state: Arc::new(RwLock::new(user_state)),
+        user_state: Cell::new(Some(user_state)),
         build: Arc::new(build),
         update: Arc::new(update),
 


### PR DESCRIPTION
- relates to https://github.com/hi-ogawa/nih-plug-examples/pull/4

No idea what I'm doing, but it feels sensible to "move" user state to window?
Not sure that "spec" guarantees `editor/spawn` will be called only once during the plugin lifetime.
cf. https://github.com/free-audio/clap/blob/84531b931c12285097746a9cae77690a680b8aa0/include/clap/ext/gui.h#L16-L30

## notes

Maybe what's unusual is that `llq::Producer/Consumer` should be `Sync` by the same reasoning as 

> Since you need an &mut Carton to write to the pointer, and the borrow checker enforces that mutable references must be exclusive, there are no soundness issues making Carton sync either.

from https://doc.rust-lang.org/nomicon/send-and-sync.html

If they are `Sync`, then it allows `Arc<RwLock<llq::Producer<T>>>` to be passed to `create_egui_editor` callbacks.
For `process` callback, it grabs `&mut MyPlugin`, so we can define `MyPlugin.consumer: llq::Consumer<T>` directly.